### PR TITLE
Pin Angular version

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -10,7 +10,7 @@
             { "mode": "auto" }
         ]
     },
-	"postCreateCommand": "export NG_CLI_ANALYTICS=ci && npm i -g @angular/cli && npm install",
+	"postCreateCommand": "export NG_CLI_ANALYTICS=ci && npm i -g @angular/cli@14 && npm install",
 	"build": {
 		"dockerfile": ".devcontainer\\Dockerfile",
 		"args": {


### PR DESCRIPTION
This PR fixes a bug where the app fails run due to a mismatch between the versions Angular and Node.js,

The issue was caused due to an issue in `.devcontainer.json`. The version of Node.js is explicitly defined as `16-bullseye`, yet in `postCreateCommand` we were installing the Angular CLI without providing a version. As a result, the latest version of Angular CLI is installed when the docker container is built. The latest version of Angular CLI no longer supports Node.js 16, causing the error.

This PR resolves the issue by pinning the Angular CLI version to that used int he Guardian Care app (Angular v14).