### PR TITLE
Forwarding ports by default

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -17,5 +17,11 @@
 			"VARIANT": "16-bullseye"
 		}
 	},
-	"remoteUser": "node"
+	"remoteUser": "node",
+
+	"forwardPorts": [3000, 4200],
+  	"portsAttributes": {
+    "3000": { "label": "Juice Shop API" },
+    "4200": { "label": "Angular Dev Server" }
+	}
 }


### PR DESCRIPTION
### Description

Forwarding port 3000 in the devcontainer. This should prevent an issue where the products on the juice shop page did not display.

Also labelling the ports.